### PR TITLE
Add more models for analysis

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,12 @@
+name = "CAP_SMC_Project"
+uuid = "af8fb454-345d-4924-8b11-c7c20e56add5"
+authors = ["George Rauta", "Daniel Saurez", "Thomas Hewatt"]
+version = "0.0.1"
+
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ With this limitation in mind, we do not expect to always be able to reduce the c
 
 ## How to Run
 
-This section will be updated as more code is added to this project.
+To run this code, please first install Julia at: https://julialang.org/downloads/.
+
+To open this project and download all of the required dependencies, run the following:
+
+```julia
+] activate `path to local repo`
+instantiate
+```
+
+You may then run any of the included `demos` files included by running:
+
+```julia
+include("demos/`path to demo`")
+```
+
+
 
 

--- a/demos/models.jl
+++ b/demos/models.jl
@@ -1,0 +1,27 @@
+using CAP_SMC_Project
+using Combinatorics
+
+# TODO: Calculate Shapley from payoff
+players = [:A, :B, :C]
+n_players = length(players)
+coalitions = combinations(players)
+values = [0,0,0, 600, 600, 0, 900]
+
+payoff = load_payoffs(coalitions, values)
+
+shapley_A = ((2 * 0) + 600 + 600 + (2 * 900)) / 6
+shapley_B = ((2 * 0) + 600 + 0 + (2 * 300)) / 6
+shapley_C = ((2 * 0) + 600 + 0 + (2 * 300)) / 6
+
+shapley = [shapley_A, shapley_B, shapley_C]
+
+let
+  model, x = core(players, payoff)
+  print(model)
+end
+
+shapley_feasible(players, payoff, shapley)
+
+max_playerwise(players, payoff)
+
+max_unfairness(players, payoff, shapley)

--- a/demos/square.jl
+++ b/demos/square.jl
@@ -7,7 +7,7 @@ model = Model(Ipopt.Optimizer)
 @variable(model, 1 >= x >= 0)
 @variable(model, 1 >= y >= 0)
 
-@constraint(model, y + x == 1)
+# @constraint(model, y + x == 1)
 
 @objective(model, Max, x^2 + y^2)
 

--- a/src/CAP_SMC_Project.jl
+++ b/src/CAP_SMC_Project.jl
@@ -1,0 +1,5 @@
+module CAP_SMC_Project
+
+include("modeling.jl")
+
+end


### PR DESCRIPTION
This PR adds multiple different models that:

- Check the feasibility of the Shapley value
- Check the maximum possible outcome for a particular player
- Check the point most distant from the Shapley
- Possibly more in the future...

The point is to be able to better analyze the core in terms of "unfairness" and checking to see what the extremes are in this case. We choose this approach over our original attempt to use simplex-style traversals of the boundary due to the better scalability of this method and the more intuitive results of these models, such as, this is the best the player could do at the expense of all others.