### PR TITLE
Add fairest point model

### DIFF
--- a/demos/models.jl
+++ b/demos/models.jl
@@ -39,3 +39,5 @@ shapley_feasible(players, payoff, shapley)
 max_playerwise(players, payoff)
 
 max_unfairness(players, payoff, shapley)
+
+max_fairness(players, payoff, shapley)

--- a/demos/square.jl
+++ b/demos/square.jl
@@ -33,9 +33,19 @@ set_silent(model)
 @variable(model, 1 >= x >= 0, start = 0.5 + 0.0001)
 @variable(model, 1 >= y >= 0, start = 0.5 - 0.0001)
 
+@constraint(model, y + x == 1)
+
 @objective(model, Max, x^2 + y^2)
 
-@constraint(model, y + x == 1)
+print(model)
+
+optimize!(model)
+
+println("Furthest distance is: $(sqrt(objective_value(model)))")
+
+println("X: $(value(x)), Y: $(value(y))")
+
+@objective(model, Min, x^2 + y^2)
 
 print(model)
 

--- a/demos/square.jl
+++ b/demos/square.jl
@@ -51,6 +51,6 @@ print(model)
 
 optimize!(model)
 
-println("Furthest distance is: $(sqrt(objective_value(model)))")
+println("Closest distance is: $(sqrt(objective_value(model)))")
 
 println("X: $(value(x)), Y: $(value(y))")

--- a/demos/unfair.jl
+++ b/demos/unfair.jl
@@ -17,3 +17,5 @@ shapley_feasible(players, payoff, shapley)
 max_playerwise(players, payoff)
 
 max_unfairness(players, payoff, shapley; start_values = [10 + 0.0001, 10 - 0.0001])
+
+max_fairness(players, payoff, shapley)

--- a/src/modeling.jl
+++ b/src/modeling.jl
@@ -58,6 +58,28 @@ function max_unfairness(players, payoff, shapley; start_values = nothing)
   println("Distance to farthest point from Shapley: $(sqrt(objective_value(model)))")
 end
 
+function max_fairness(players, payoff, shapley; start_values = nothing)
+  if !isnothing(start_values)
+    start_values = start_values .- shapley
+  end
+
+  model, x = core(players, payoff; shift = shapley, start_values = start_values)
+  n_players = length(x)
+
+  @objective(model, Min, sum(x[1:n_players].^2))
+
+  Random.seed!(1337)
+  optimize!(model);
+  
+  @assert is_solved_and_feasible(model)
+  # println(solution_summary(model; verbose = true))
+
+  println("Shapley outcome was: $(shapley)")
+  println("Unfair outcome was: $(value.(x) .+ shapley)")
+  println("Distance to farthest point from Shapley: $(sqrt(objective_value(model)))")
+end
+
+
 function max_playerwise(players, payoff)
   model, x = core(players, payoff)
   n_players = length(x)

--- a/src/modeling.jl
+++ b/src/modeling.jl
@@ -4,7 +4,7 @@ using Ipopt
 using Combinatorics
 using Random
 
-export core, load_payoffs, max_unfairness, max_playerwise, shapley_feasible
+export core, load_payoffs, max_unfairness, max_fairness, max_playerwise, shapley_feasible
 
 function core(players, payoff; shift = zeros(length(players)), solver = Ipopt.Optimizer, start_values = nothing)
 
@@ -47,7 +47,6 @@ function max_unfairness(players, payoff, shapley; start_values = nothing)
 
   @objective(model, Max, sum(x[1:n_players].^2))
 
-  Random.seed!(1337)
   optimize!(model);
   
   @assert is_solved_and_feasible(model)
@@ -68,15 +67,14 @@ function max_fairness(players, payoff, shapley; start_values = nothing)
 
   @objective(model, Min, sum(x[1:n_players].^2))
 
-  Random.seed!(1337)
   optimize!(model);
   
   @assert is_solved_and_feasible(model)
   # println(solution_summary(model; verbose = true))
 
   println("Shapley outcome was: $(shapley)")
-  println("Unfair outcome was: $(value.(x) .+ shapley)")
-  println("Distance to farthest point from Shapley: $(sqrt(objective_value(model)))")
+  println("Fair outcome was: $(value.(x) .+ shapley)")
+  println("Distance to closest point from Shapley: $(sqrt(objective_value(model)))")
 end
 
 
@@ -87,7 +85,6 @@ function max_playerwise(players, payoff)
   for player_id in 1:n_players
     @objective(model, Max, x[player_id])
 
-    Random.seed!(1337)
     optimize!(model)
 
     @assert is_solved_and_feasible(model)
@@ -103,7 +100,6 @@ function shapley_feasible(players, payoff, shapley)
   shapley_point = Dict(zip(x, shapley))
 
 
-  Random.seed!(1337)
   feasible = isempty(primal_feasibility_report(model, shapley_point))
 
   println("Shapley outcome was: $(shapley)")


### PR DESCRIPTION
This is in response to the idea that the Shapley value may not be in the core, see issue #19. If the Shapley is in the core the this is the fairest feasible point. If it is not in the core, then we can find the "fairest" point by using Quadratic programming to find the point closest to the Shapley that is still in the core.

The `square.jl` demo shows this feature off the best since in the final case, the origin point is not in the line segment and yet is able to find the constrained point that is in fact the midpoint in between the two endpoints of the segment.