### PR TITLE
Introduce Monte Carlo for Shapley

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -13,3 +13,9 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 JuMP = "1.23.2"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/demos/models.jl
+++ b/demos/models.jl
@@ -1,20 +1,20 @@
 using CAP_SMC_Project
 using Combinatorics
 
-# TODO: Calculate Shapley from payoff
-
 #Establishes Provinces
-players = ["A", "B", "C"]
+players = auto_generate_playertags(3)
 
 total_budget = 1500.0
 
 #Establishes Conversion Rates Dict
 ConversionRates = Dict{Int64, Int64}(900 => 600, 1500 => 900, 2000 => 1500)
 
-println(calculate_budgets(players, total_budget))
+prov_budgets = calculate_budgets(players, total_budget)
+
+println(prov_budgets)
 
 # Generate the power set of provinces
-coalitions = powerset(calculate_budgets(players, total_budget))
+coalitions = powerset(prov_budgets)
 
 payoff = create_payoffs(coalitions, ConversionRates)
 println(payoff)

--- a/demos/models.jl
+++ b/demos/models.jl
@@ -21,6 +21,11 @@ println(payoff)
 
 shapley = shapley_point(payoff)
 
+mc_shapley = monte_carlo_shapley_point(players, payoff, 900)
+
+@assert norm(shapley - mc_shapley) < 1
+@assert sum(mc_shapley) == payoff[players]
+
 let
   model, x = core(players, payoff)
   print(model)

--- a/demos/models.jl
+++ b/demos/models.jl
@@ -1,5 +1,6 @@
 using CAP_SMC_Project
 using Combinatorics
+using LinearAlgebra
 
 #Establishes Provinces
 players = auto_generate_playertags(3)
@@ -21,7 +22,7 @@ println(payoff)
 
 shapley = shapley_point(payoff)
 
-mc_shapley = monte_carlo_shapley_point(players, payoff, 900)
+mc_shapley = monte_carlo_shapley_point(players, payoff, 600)
 
 @assert norm(shapley - mc_shapley) < 1
 @assert sum(mc_shapley) == payoff[players]

--- a/demos/monte_carlo.jl
+++ b/demos/monte_carlo.jl
@@ -2,8 +2,9 @@ using LinearAlgebra
 using CAP_SMC_Project
 using Random
 using Combinatorics
+using Plots
 
-nplayers = 8
+nplayers = 50
 players = auto_generate_playertags(nplayers)
 
 # shapley_list = []
@@ -21,22 +22,49 @@ players = auto_generate_playertags(nplayers)
 # values = Float64[]
 # shapley_mat * values[2:end]
 
+a = 10
+b = 5
+
 payoff = Dict()
 for coalition in powerset(players)
-  val = 300 * length(coalition) + 50*length(coalition)^2
+  val = a * length(coalition) + b * length(coalition)^2
   push!(payoff, coalition => val)
 end
 
+println("Predicated Shapley for all should be $(a + b * length(players))")
+
+maxval = a * nplayers + b
 
 rng = Xoshiro(1337)
 shapley_values = Dict(zip(players, zeros(length(players))))
 
-trials = factorial(nplayers) / 10
+p = 0.95
+t = 1
+
+trials = ceil(Int64, maxval^2 * nplayers * log(2 / (1 - 0.95^(1/nplayers))) / (2 * t^2))
 
 for i in 1:trials
+  if i % 1_000_000 == 0
+    println("On trial $i")
+  end
   run_shapley_round!(shapley_values, payoff, players[randperm(rng, nplayers)])
 end
 
 for player in players
   println("$player: $(shapley_values[player] / trials)")
+end
+
+marginal_points = Dict(player => [] for player in players)
+
+for i in 1:100_000
+  shapley_values = Dict(zip(players, zeros(length(players))))
+  perm = players[randperm(rng, nplayers)]
+  run_shapley_round!(shapley_values, payoff, perm)
+  if shapley_values[first(players)] <= 0
+    @show perm
+    break
+  end
+  for player in keys(shapley_values)
+    push!(marginal_points[player], shapley_values[player])
+  end
 end

--- a/demos/monte_carlo.jl
+++ b/demos/monte_carlo.jl
@@ -28,3 +28,4 @@ mc_shapley = monte_carlo_shapley_point(players, payoff, maxval)
 shapley = fill(pred_shapley, nplayers)
 
 @assert norm(shapley .- mc_shapley) < 1
+println("Difference in known Shapley vs Monte Carlo Shapley is $(norm(shapley .- mc_shapley))")

--- a/demos/shapley_mat.jl
+++ b/demos/shapley_mat.jl
@@ -1,0 +1,42 @@
+using LinearAlgebra
+using CAP_SMC_Project
+using Random
+using Combinatorics
+
+nplayers = 8
+players = auto_generate_playertags(nplayers)
+
+# shapley_list = []
+
+# ncoalitions = 2^(length(players))
+
+# for idx in 2:ncoalitions
+#   vec = zeros(ncoalitions)
+#   vec[idx] = 1.0
+#   payoff = Dict(zip(powerset(players), vec))
+#   push!(shapley_list, shapley_point(payoff))
+# end
+
+# shapley_mat = hcat(shapley_list...)
+# values = Float64[]
+# shapley_mat * values[2:end]
+
+payoff = Dict()
+for coalition in powerset(players)
+  val = 300 * length(coalition) + 50*length(coalition)^2
+  push!(payoff, coalition => val)
+end
+
+
+rng = Xoshiro(1337)
+shapley_values = Dict(zip(players, zeros(length(players))))
+
+trials = factorial(nplayers) / 10
+
+for i in 1:trials
+  run_shapley_round!(shapley_values, payoff, players[randperm(rng, nplayers)])
+end
+
+for player in players
+  println("$player: $(shapley_values[player] / trials)")
+end

--- a/src/payoff.jl
+++ b/src/payoff.jl
@@ -16,9 +16,12 @@ end
 function auto_generate_playertags(n::Int)
   @assert n > 0
 
-  return sort(["P_$i" for i in 1:n])
-end
+  pow = ceil(Int64, log2(n)/log2(26))
 
+  name_gen = Iterators.product(fill('A':'Z', pow)...)
+
+  return sort(["P_$(name...)" for (name, _) in zip(name_gen, 1:n)])
+end
 
 # Function to calculate budgets and return a vector of Province structs
 function calculate_budgets(players, total_resources::Float64 = 100.0; budget_func = budget_function)

--- a/src/payoff.jl
+++ b/src/payoff.jl
@@ -16,7 +16,7 @@ end
 function auto_generate_playertags(n::Int)
   @assert n > 0
 
-  return ["P_$i" for i in 1:n]
+  return sort(["P_$i" for i in 1:n])
 end
 
 

--- a/src/payoff.jl
+++ b/src/payoff.jl
@@ -1,10 +1,10 @@
 using Combinatorics
 
-export Province, create_payoffs, calculate_budgets
+export Province, create_payoffs, calculate_budgets, auto_generate_playertags
 
 # Province struct
 struct Province
-    name::String
+    name
     money::Float64
 end
 
@@ -13,8 +13,15 @@ function budget_function(x::Int)
     return 1.0 / x
 end
 
+function auto_generate_playertags(n::Int)
+  @assert n > 0
+
+  return ["P_$i" for i in 1:n]
+end
+
+
 # Function to calculate budgets and return a vector of Province structs
-function calculate_budgets(players::Vector{String}, total_resources::Float64 = 100.0; budget_func = budget_function)
+function calculate_budgets(players, total_resources::Float64 = 100.0; budget_func = budget_function)
     num_provinces = length(players)
     raw_budgets = Vector{Float64}(undef, num_provinces)
     total_raw_budget = 0.0
@@ -29,7 +36,7 @@ function calculate_budgets(players::Vector{String}, total_resources::Float64 = 1
 
     for i in 1:num_provinces
         normalized_budget = (raw_budgets[i] / total_raw_budget) * total_resources
-        country[i] = Province(players[i], normalized_budget) 
+        country[i] = Province(players[i], normalized_budget)
     end
 
     return country
@@ -43,7 +50,7 @@ function create_payoffs(power_set, conversion_rates::Dict{Int,Int})
             continue;
         end
         val_sum = 0
-        name_list = String[]
+        name_list = []
 
         for prov in set
             val_sum += prov.money

--- a/src/shapley.jl
+++ b/src/shapley.jl
@@ -34,14 +34,15 @@ end
 function run_shapley_round!(shapley_values, payoffs, perm)
   coalition = []
 
+  val = 0
+  next_val = 0
+
   for player in perm
-    prev_value = get(payoffs, coalition, 0)
+    coalition = sort(push!(coalition, player))
+    next_val = get(payoffs, coalition, 0)
 
-    sort!(push!(coalition, player))
-
-    current_value = get(payoffs, coalition, 0)
-
-    shapley_values[player] += current_value - prev_value
+    shapley_values[player] += next_val - val
+    val = next_val
   end
 
   shapley_values

--- a/test/shapley.jl
+++ b/test/shapley.jl
@@ -1,17 +1,11 @@
 using Test
 
-players = [:A, :B]
+@testset "Small Shapley" begin
+  players = [:A, :B]
+  payoff = Dict(zip(powerset(players), [0, 5, 5, 20]))
+  @test shapley_point(payoff) == [10.0, 10.0]
 
-payoff = Dict(zip(powerset(players), [0, 5, 5, 20]))
-
-shapley = shapley_point(payoff)
-
-@test shapley == [10.0, 10.0]
-
-players = [:A, :B, :C]
-
-payoff = Dict(zip(powerset(players), [0, 0, 0, 0, 600, 600, 0, 900]))
-
-shapley = shapley_point(payoff)
-
-@test shapley == [500, 200, 200]
+  players = [:A, :B, :C]
+  payoff = Dict(zip(powerset(players), [0, 0, 0, 0, 600, 600, 0, 900]))
+  @test shapley_point(payoff) == [500, 200, 200]
+end

--- a/test/shapley.jl
+++ b/test/shapley.jl
@@ -1,0 +1,17 @@
+using Test
+
+players = [:A, :B]
+
+payoff = Dict(zip(powerset(players), [0, 5, 5, 20]))
+
+shapley = shapley_point(payoff)
+
+@test shapley == [10.0, 10.0]
+
+players = [:A, :B, :C]
+
+payoff = Dict(zip(powerset(players), [0, 0, 0, 0, 600, 600, 0, 900]))
+
+shapley = shapley_point(payoff)
+
+@test shapley == [500, 200, 200]


### PR DESCRIPTION
This PR introduces functionality for estimation of the Shapley value through random sampling. This allows for calculation of a Shapley value for even a large amount of players relatively quickly.

Investigation needs to be done to determine how many trials need to be conducted for a certain level of confidence in the result. The current method does basic random sampling of permutations but this may be changed/improved.