### PR TITLE
Implementing mechanisms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/demos/mech_models.jl
+++ b/demos/mech_models.jl
@@ -18,7 +18,8 @@ payoff = create_payoffs(coalitions, ConversionRates)
 og_shapley = shapley_point(payoff)
 
 # Generate the power set of provinces
-country = redistribution(country, 300)
+tax = (700 + 400 + 400) * 0.1
+country = redistribution(country, tax)
 coalitions = powerset(country)
 
 payoff = create_payoffs(coalitions, ConversionRates)

--- a/demos/mech_models.jl
+++ b/demos/mech_models.jl
@@ -8,23 +8,22 @@ provA = Province(players[1], 700)
 provB = Province(players[2], 400)
 provC = Province(players[3], 400)
 
-#Establishes Prov names
-country = [provA, provB, provC]
-
 #Establishes Conversion Rates Dict
 ConversionRates = set_conversions(ntimes = 4, starting_price = 200)
 
+#Establishes Prov names
+country = [provA, provB, provC]
+coalitions = powerset(country)
+payoff = create_payoffs(coalitions, ConversionRates)
+og_shapley = shapley_point(payoff)
+
 # Generate the power set of provinces
+country = redistribution(country, 300)
 coalitions = powerset(country)
 
 payoff = create_payoffs(coalitions, ConversionRates)
 
 shapley = shapley_point(payoff)
-
-mc_shapley = monte_carlo_shapley_point(players, payoff, 490)
-
-@assert norm(shapley - mc_shapley) < 1
-@assert sum(mc_shapley) == payoff[players]
 
 let
   model, x = core(players, payoff)
@@ -35,10 +34,12 @@ shapley_feasible(players, payoff, shapley)
 
 max_playerwise(players, payoff)
 
-max_unfairness(players, payoff, shapley; start_values = [490, 950, 0])
+max_unfairness(players, payoff, shapley; start_values = [950, 245, 245])
 
 fair_point = max_fairness(players, payoff, shapley);
 
 equal_point = strongly_egalitarian_core(players, payoff);
 
 println("Distance between the fair point and the equal point is $(norm(fair_point .- equal_point)).")
+
+println("Distance between the orignal Shapley and the new Shapley is $(norm(og_shapley .- shapley)).")

--- a/demos/models.jl
+++ b/demos/models.jl
@@ -9,13 +9,15 @@ provB = Province(players[2], 400)
 provC = Province(players[3], 400)
 
 #Establishes Prov names
-Country = [provA, provB, provC]
+country = [provA, provB, provC]
+
+country = redistribution(country, 300)
 
 #Establishes Conversion Rates Dict
 ConversionRates = set_conversions(ntimes = 4, starting_price = 200)
 
 # Generate the power set of provinces
-coalitions = powerset(Country)
+coalitions = powerset(country)
 
 payoff = create_payoffs(coalitions, ConversionRates)
 

--- a/demos/monte_carlo.jl
+++ b/demos/monte_carlo.jl
@@ -2,7 +2,6 @@ using LinearAlgebra
 using CAP_SMC_Project
 using Random
 using Combinatorics
-using Plots
 
 nplayers = 12
 players = auto_generate_playertags(nplayers)

--- a/src/CAP_SMC_Project.jl
+++ b/src/CAP_SMC_Project.jl
@@ -2,6 +2,7 @@ module CAP_SMC_Project
 
 include("payoff.jl")
 include("shapley.jl")
+include("mechanism.jl")
 include("modeling.jl")
 
 end

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -1,0 +1,69 @@
+using Combinatorics
+
+export redistribution, benefit, penalty
+
+function redistribution(country, budget; tax_type = :flat)
+
+  @assert budget >= 0
+
+  nplayers = length(country)
+  real_budget = 0
+
+  new_country = []
+
+  for prov in country
+    if tax_type == :flat
+      tax = minimum([prov.money, ceil(budget / nplayers)])
+      push!(new_country, Province(prov.name, prov.money - tax))
+      real_budget += tax
+    end
+  end
+  
+  new_country = sort(new_country; by = x -> x.money)
+
+  for (idx, prov) in enumerate(new_country[2:end])
+
+    next_goal = prov.money
+
+    money_to_reach_goal = 0
+    available_money = 0
+
+    for i in 1:(idx)
+      money_to_reach_goal += next_goal - new_country[i].money
+      available_money += new_country[i].money
+    end
+
+    money_to_use = min(real_budget, money_to_reach_goal)
+    real_budget -= money_to_use
+
+    real_goal = min(next_goal, (available_money + money_to_use) / (idx))
+
+    for i in 1:idx
+      new_country[i].money = real_goal
+    end
+  end
+
+  final_distribution = real_budget / nplayers
+  for prov in new_country
+    prov.money += final_distribution
+  end
+  
+  sort_by_name(new_country)
+end
+
+sort_by_name(country) = sort(country; by = x -> x.name)
+
+
+function benefit(players, payoff, reward)
+
+  for coalition in powerset(players)
+    if isempty(coalition); continue; end
+    payoff[coalition] += reward
+  end
+
+  payoff[players] -= reward
+
+  payoff
+end
+
+penalty(players, payoff, reward) = benefit(players, payoff, -reward)

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -1,6 +1,6 @@
 using Combinatorics
 
-export redistribution, benefit, penalty
+export redistribution, sort_by_name, benefit, penalty
 
 function redistribution(country, budget; tax_type = :flat)
 

--- a/src/payoff.jl
+++ b/src/payoff.jl
@@ -3,7 +3,7 @@ using Combinatorics
 export Province, create_payoffs, calculate_budgets, auto_generate_playertags, set_conversions
 
 # Province struct
-struct Province
+mutable struct Province
     name
     money::Float64
 end

--- a/test/mechanism.jl
+++ b/test/mechanism.jl
@@ -1,8 +1,6 @@
 using Test
 using CAP_SMC_Project
 
-sort_by_name(country) = sort(country; by = x -> x.name)
-
 function test_redistribution(country, budget, tax_type, expected_money) 
   res = sort_by_name(redistribution(country, budget; tax_type = tax_type))
   for (idx, val) in enumerate(expected_money)

--- a/test/mechanism.jl
+++ b/test/mechanism.jl
@@ -1,0 +1,27 @@
+using Test
+using CAP_SMC_Project
+
+sort_by_name(country) = sort(country; by = x -> x.name)
+
+function test_redistribution(country, budget, tax_type, expected_money) 
+  res = sort_by_name(redistribution(country, budget; tax_type = tax_type))
+  for (idx, val) in enumerate(expected_money)
+    @test res[idx].name == country[idx].name && res[idx].money == expected_money[idx]
+  end
+end
+
+@testset "Redistribution" begin
+
+  nplayers = 3
+  players = auto_generate_playertags(nplayers)
+  provA = Province(players[1], 700)
+  provB = Province(players[2], 400)
+  provC = Province(players[3], 400)
+  country = [provA, provB, provC]
+
+  test_redistribution(country, 0, :flat, [700, 400, 400])
+
+  test_redistribution(country, 300, :flat, [600, 450, 450])
+
+  test_redistribution(country, 3000, :flat, [500, 500, 500])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,9 @@
+using Test
+
+@testset "Shapley" begin
+  include("shapley.jl")
+end
+
+@testset "Mechanisms" begin
+  include("mechanism.jl")
+end

--- a/test/shapley.jl
+++ b/test/shapley.jl
@@ -1,4 +1,6 @@
 using Test
+using CAP_SMC_Project
+using Combinatorics
 
 @testset "Small Shapley" begin
   players = [:A, :B]


### PR DESCRIPTION
This PR is meant to implement the mechanism for our simulation. It simulates the national government taking a certain budgeted tax from all provinces, with the method of taxation able to vary (flat, proportional, etc.), and then distributing that money so that poorer provinces get the most funding.

The idea here is that by this redistribution of wealth through taxation and reinvestment, the leverage of provinces equalizes so that the core is smaller while still containing the Shapley value, thus increasing the fairness of the outcome.